### PR TITLE
🐛 [useElementRect] Improve hook

### DIFF
--- a/.changeset/silver-flies-joke.md
+++ b/.changeset/silver-flies-joke.md
@@ -1,0 +1,5 @@
+---
+"vurtis": patch
+---
+
+updateRect now takes element as an argument.

--- a/src/hooks/useElementRect.ts
+++ b/src/hooks/useElementRect.ts
@@ -52,7 +52,12 @@ export function useElementRect(round = false) {
     [round],
   );
 
-  const {scrollX, scrollY, visibleWidth, visibleHeight} = useWindowScroll({
+  const {
+    scrollX,
+    scrollY,
+    visibleWidth: windowWidth,
+    visibleHeight: windowHeight,
+  } = useWindowScroll({
     updateStrategy: 'aggressive',
   });
 
@@ -65,12 +70,16 @@ export function useElementRect(round = false) {
 
   useIsoEffect(() => {
     updateRect(ref.current);
-  }, [updateRect, scrollX, scrollY, visibleWidth, visibleHeight]);
+  }, [updateRect, scrollX, scrollY, windowWidth, windowHeight]);
 
   return {
     ref,
     updateRect,
     // Destructuring the `rect` as an alternative to memoizing the object.
     ...rect,
+    // Returning some of our `window` values as they could
+    // be useful to consumers.
+    windowWidth,
+    windowHeight,
   };
 }

--- a/src/hooks/useElementRect.ts
+++ b/src/hooks/useElementRect.ts
@@ -36,27 +36,35 @@ function extractRectSubset(
   };
 }
 
-// TODO: Do we want to create and provide the `ref`,
-// or accept it as an option?
 export function useElementRect(round = false) {
   const ref = useRef<HTMLElement | null>(null);
   const [rect, setRect] = useState<RectSubset>(INITIAL_RECT);
 
-  const updateRect = useCallback(() => {
-    if (!ref.current) return;
+  const updateRect = useCallback(
+    (element?: HTMLElement | null) => {
+      if (!element) return;
 
-    const domRect = ref.current.getBoundingClientRect();
-    setRect(extractRectSubset(domRect, round));
-  }, [round]);
+      const domRect = element.getBoundingClientRect();
+      ref.current = element;
+
+      setRect(extractRectSubset(domRect, round));
+    },
+    [round],
+  );
 
   const {scrollX, scrollY, visibleWidth, visibleHeight} = useWindowScroll({
     updateStrategy: 'aggressive',
   });
 
-  useResizeObserver({ref, onResize: updateRect});
+  useResizeObserver({
+    ref,
+    onResize: () => {
+      updateRect(ref.current);
+    },
+  });
 
   useIsoEffect(() => {
-    updateRect();
+    updateRect(ref.current);
   }, [updateRect, scrollX, scrollY, visibleWidth, visibleHeight]);
 
   return {

--- a/src/hooks/useElementRect.ts
+++ b/src/hooks/useElementRect.ts
@@ -39,7 +39,7 @@ function extractRectSubset(
 // TODO: Do we want to create and provide the `ref`,
 // or accept it as an option?
 export function useElementRect(round = false) {
-  const ref = useRef<HTMLElement>(null);
+  const ref = useRef<HTMLElement | null>(null);
   const [rect, setRect] = useState<RectSubset>(INITIAL_RECT);
 
   const updateRect = useCallback(() => {


### PR DESCRIPTION
I am going back to the "element callback ref" pattern for the `updateRect()` method. This should hopefully make it easier to use.