### PR TITLE
⚗️ [useResizeObserver] Add optional `forceReconnect` prop and expose `observerRef`

### DIFF
--- a/.changeset/blue-seals-reply.md
+++ b/.changeset/blue-seals-reply.md
@@ -1,0 +1,5 @@
+---
+"vurtis": patch
+---
+
+useElementRect now requires an object argument.

--- a/.changeset/odd-spiders-lay.md
+++ b/.changeset/odd-spiders-lay.md
@@ -1,0 +1,5 @@
+---
+"vurtis": patch
+---
+
+Expose observerRef from useResizeObserver and useElementRect.

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,6 +1,6 @@
 export * from './useResizeObserver';
 
-export {useElementRect} from './useElementRect';
+export {useElementRect, type ElementRectOptions} from './useElementRect';
 export {useIsoEffect} from './useIsoEffect';
 export {useMounted} from './useMounted';
 

--- a/src/hooks/useElementRect.ts
+++ b/src/hooks/useElementRect.ts
@@ -1,7 +1,10 @@
 import {useCallback, useRef, useState} from 'react';
 
 import {useIsoEffect} from './useIsoEffect';
-import {useResizeObserver} from './useResizeObserver';
+import {
+  useResizeObserver,
+  type ResizeObserverOptions,
+} from './useResizeObserver';
 import {useWindowScroll} from './useWindowScroll';
 
 interface RectSubset {
@@ -11,6 +14,11 @@ interface RectSubset {
   left: number;
   width: number;
   height: number;
+}
+
+export interface ElementRectOptions {
+  forceReconnect?: ResizeObserverOptions['forceReconnect'];
+  round?: boolean;
 }
 
 const INITIAL_RECT: RectSubset = {
@@ -36,13 +44,19 @@ function extractRectSubset(
   };
 }
 
-export function useElementRect(round = false) {
+export function useElementRect({
+  forceReconnect = 0,
+  round = false,
+}: ElementRectOptions) {
   const ref = useRef<HTMLElement | null>(null);
   const [rect, setRect] = useState<RectSubset>(INITIAL_RECT);
 
   const updateRect = useCallback(
     (element?: HTMLElement | null) => {
-      if (!element) return;
+      if (!element) {
+        setRect(INITIAL_RECT);
+        return;
+      }
 
       const domRect = element.getBoundingClientRect();
       ref.current = element;
@@ -63,6 +77,7 @@ export function useElementRect(round = false) {
 
   useResizeObserver({
     ref,
+    forceReconnect,
     onResize: () => {
       updateRect(ref.current);
     },
@@ -79,6 +94,8 @@ export function useElementRect(round = false) {
     ...rect,
     // Returning some of our `window` values as they could
     // be useful to consumers.
+    scrollX,
+    scrollY,
     windowWidth,
     windowHeight,
   };

--- a/src/hooks/useElementRect.ts
+++ b/src/hooks/useElementRect.ts
@@ -75,7 +75,7 @@ export function useElementRect({
     updateStrategy: 'aggressive',
   });
 
-  useResizeObserver({
+  const {observerRef} = useResizeObserver({
     ref,
     forceReconnect,
     onResize: () => {
@@ -90,6 +90,7 @@ export function useElementRect({
   return {
     ref,
     updateRect,
+    observerRef,
     // Destructuring the `rect` as an alternative to memoizing the object.
     ...rect,
     // Returning some of our `window` values as they could

--- a/src/hooks/useResizeObserver/useResizeObserver.ts
+++ b/src/hooks/useResizeObserver/useResizeObserver.ts
@@ -41,10 +41,11 @@ export function useResizeObserver<T extends HTMLElement = HTMLElement>({
   box = 'border-box',
   forceReconnect = 0,
   onResize,
-}: ResizeObserverOptions<T>): Size {
+}: ResizeObserverOptions<T>) {
   const [{width, height}, setSize] = useState<Size>(initialSize);
-
   const previousSize = useRef<Size>({...initialSize});
+
+  const observerRef = useRef<ResizeObserver>();
   const onResizeRef = useRef<((size: Size) => void) | undefined>(onResize);
 
   const isMounted = useMounted();
@@ -52,7 +53,7 @@ export function useResizeObserver<T extends HTMLElement = HTMLElement>({
   useIsoEffect(() => {
     if (!ref.current || !supportResizeObserver()) return;
 
-    const observer = new ResizeObserver(([entry]) => {
+    observerRef.current = new ResizeObserver(([entry]) => {
       const camelBox = convertKebabToCamel(box);
 
       const newWidth = extractSize(entry, camelBox, 'inlineSize');
@@ -76,12 +77,12 @@ export function useResizeObserver<T extends HTMLElement = HTMLElement>({
       }
     });
 
-    observer.observe(ref.current, {box});
+    observerRef.current.observe(ref.current, {box});
 
     return () => {
-      observer.disconnect();
+      observerRef.current?.disconnect();
     };
   }, [box, ref, forceReconnect, isMounted]);
 
-  return {width, height};
+  return {width, height, observerRef};
 }

--- a/src/hooks/useResizeObserver/useResizeObserver.ts
+++ b/src/hooks/useResizeObserver/useResizeObserver.ts
@@ -17,6 +17,10 @@ interface Size {
 export interface ResizeObserverOptions<T extends HTMLElement = HTMLElement> {
   ref: RefObject<T>;
   box?: ResizeKebabBox;
+  // In case you need to `disconnect/re-connect` the observer,
+  // perhaps because you are re-using a `ref` for different `nodes`,
+  // you can increment the `forceReconnect` prop.
+  forceReconnect?: number;
   onResize?: (size: Size) => void;
 }
 
@@ -35,6 +39,7 @@ const initialSize: Size = {
 export function useResizeObserver<T extends HTMLElement = HTMLElement>({
   ref,
   box = 'border-box',
+  forceReconnect = 0,
   onResize,
 }: ResizeObserverOptions<T>): Size {
   const [{width, height}, setSize] = useState<Size>(initialSize);
@@ -76,7 +81,7 @@ export function useResizeObserver<T extends HTMLElement = HTMLElement>({
     return () => {
       observer.disconnect();
     };
-  }, [box, ref, isMounted]);
+  }, [box, ref, forceReconnect, isMounted]);
 
   return {width, height};
 }


### PR DESCRIPTION
In a continued effort to make `useResizeObserver + useElementRect` maximally useful to consumer's, I am doing two things:

1. A new optional `forceReconnect?: number;` prop.
   - You can leverage this to increment the `forceReconnect` value, in turn re-running the `effect` that `disconnect/observer` an element.
   - This is useful in cases where you are re-using a `ref` for different nodes... I realize this is an anti-pattern, but I also feel like some fringe use-cases could benefit from this and it shouldn't really cost us complexity.
2. Now returning a `observerRef` from both `useResizeObserver + useElementRect`.
   - Doing this just in case there are scenarios where you might need to call `observerRef.current.disconnect()`.
   - I'd prefer to _only return the disconnect_ within a `ref`, but I think that gets weird in terms of `this/instance` binding.